### PR TITLE
Update openapi.json

### DIFF
--- a/integrations/generated/owler/openapi.json
+++ b/integrations/generated/owler/openapi.json
@@ -692,7 +692,7 @@
             },
             "name": "company_id",
             "required": true,
-            "type": "array"
+            "type": "string"
           },
           {
             "default": "10",


### PR DESCRIPTION
Fixes incorrect definition of 'array' for company_id. Should be 'string'. Owler support confirms.