### PR TITLE
Addressed the tcp connection error thrown while making tcp connection

### DIFF
--- a/integrations/manual/smtp/index.js
+++ b/integrations/manual/smtp/index.js
@@ -141,6 +141,7 @@ smtp.addAction('send', {
         if (err) reject(err);
         else resolve(data);
       }
+      conn.on('error', finish);
       conn.connect(err => {
         if (err) return finish(err);
         let auth = {


### PR DESCRIPTION
Issue: If provided host or port are incorrect, then error is being thrown and its not handled in smtp.