### PR TITLE
Adding "completed" parameter within todo query spec

### DIFF
--- a/integrations/generated/basecamp/openapi.json
+++ b/integrations/generated/basecamp/openapi.json
@@ -4534,6 +4534,13 @@
           },
           {
             "description": "",
+            "required": false,
+            "type": "boolean",
+            "name": "completed",
+            "in": "query"
+          },
+          {
+            "description": "",
             "required": true,
             "type": "string",
             "name": "todolistId",


### PR DESCRIPTION
Fixes #23 (although if this is a generated `json` file, probably would be worth to overwrite it).

In short, this showcases how can we pass the `completed` query parameter to the endpoint in order to retrieve this endpoint. The `status` one is also missing. I've opened an [issue](https://github.com/basecamp/bc3-api/issues/210) at their API to showcase this problem, but in the meantime would be nice if you guys could update the generated json files for the `todos` API spec to reflect this parameter.

As an additional note, the `todolist` endpoint would need the `status` query parameter as well.